### PR TITLE
BACKLOG-11783 : Enable canary builds

### DIFF
--- a/packages/scripts/auto-include-plugin.js
+++ b/packages/scripts/auto-include-plugin.js
@@ -1,5 +1,20 @@
 Object.defineProperty(exports, '__esModule', {value: true});
 
+const core = require('@auto-it/core');
+
+const regExp = /^([a-zA-Z0-9-]+)-(v[0-9.]+)$/;
+// Monkey-patch determineNextVersion
+const previous = core.determineNextVersion;
+core.determineNextVersion = (lastVersion, currentVersion, bump, tag) => {
+    // Strip module name from tag
+    const match = lastVersion.match(regExp);
+    if (match) {
+        return previous(match[2], currentVersion, bump, tag);
+    }
+
+    return previous(lastVersion, currentVersion, bump, tag);
+};
+
 /** Ensure a value is an array */
 const arrayify = arr => (Array.isArray(arr) ? arr : [arr]);
 class FilterCommitsByFolderPlugin {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-11783

## Description

Enable canary build by fixing determineNextVersion when tag looks like project-name-v0.0.0 . determineNextVersion only work if the tag is like a version number, ie v0.0.0

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation

<!-- GITHUB_RELEASE PR BODY: canary-version -->
Published PR with canary version: `1.1.2-canary.64.aca7b5a.0`
<!-- GITHUB_RELEASE PR BODY: canary-version -->
