### PR TITLE
BACKLOG-12512: pass showIcons to renderer, fixed menu display position

### DIFF
--- a/packages/ui-extender/src/actions/menuAction/menuAction.jsx
+++ b/packages/ui-extender/src/actions/menuAction/menuAction.jsx
@@ -103,7 +103,8 @@ const Menu = ({context, menuContext, menuState, rootMenuContext}) => {
                     menuRenderer: MenuRenderer,
                     menuItemRenderer,
                     parentMenuContext: menuContext,
-                    rootMenuContext: rootMenuContext
+                    rootMenuContext: rootMenuContext,
+                    showIcons: context.showIcons
                 }}
                 loading={ItemLoading}
                 render={ItemRender}
@@ -277,8 +278,14 @@ const MenuActionComponent = ({context, render: Render, loading: Loading}) => {
                 // Handle click to open menu only if not in a submenu (already handled on mouse over)
                 if (!parentMenuContext) {
                     if (event.currentTarget && !context.menuUseEventPosition) {
+                        // Copy position of target element as it may be removed after load
+                        const boundingClientRect = event.currentTarget.getBoundingClientRect();
+                        const targetMock = {
+                            ...event.currentTarget,
+                            getBoundingClientRect: () => boundingClientRect
+                        };
                         menuContext.display(context, menuState, {
-                            anchorEl: event.currentTarget,
+                            anchorEl: targetMock,
                             anchorElOrigin: {
                                 vertical: 'bottom',
                                 horizontal: 'left'


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-12512

## Description
- pass showIcons to renderer so that it can be used
- fixed menu display position : in some cases the element passed was unmounted and replaced by the browser, so rather use a copy of the element with the position at the time of the click
