### PR TITLE
BACKLOG-12833

### DIFF
--- a/packages/data-helper/src/fragments/fragments.utils.js
+++ b/packages/data-helper/src/fragments/fragments.utils.js
@@ -1,4 +1,4 @@
-// TODO BACKLOG-12393 - refactor Legacy Picker into hook without lodash
+// TODO BACKLOG-12393 - remove lodash
 import * as _ from 'lodash';
 import {parseType} from 'graphql';
 import {PredefinedFragments} from '../fragments';
@@ -11,12 +11,22 @@ function findParametersInDocument(doc) {
     return [];
 }
 
+const queryCache = {};
+
 function replaceFragmentsInDocument(doc, fragments) {
+    const key = doc.definitions[0].name.value + '__' + fragments.map(f => f.gql.definitions[0].name.value).sort().join('_');
+    if (queryCache[key]) {
+        return queryCache[key];
+    }
+
     let clonedQuery = null;
     if (doc && doc.definitions) {
         clonedQuery = _.cloneDeep(doc);
         _.each(clonedQuery.definitions, def => replaceFragmentsInSelectionSet(def.selectionSet, fragments, def, clonedQuery));
+        clonedQuery.definitions[0].name.value = key;
     }
+
+    queryCache[key] = clonedQuery;
 
     return clonedQuery;
 }
@@ -83,6 +93,11 @@ function replaceFragmentsInSelectionSet(selectionSet, fragments, def, document) 
                             let existing = _.find(def.variableDefinitions, def => def.variable.name.value === name);
                             if (!existing) {
                                 let type = parseType(value, {noLocation: true});
+                                // delete type.loc;
+                                // delete type.type.loc;
+                                // if (type.type.name) {
+                                //     delete type.type.name.loc;
+                                // }
                                 def.variableDefinitions.push({
                                     kind: 'VariableDefinition',
                                     variable: {
@@ -93,6 +108,9 @@ function replaceFragmentsInSelectionSet(selectionSet, fragments, def, document) 
                                         }
                                     },
                                     type: type
+                                    // ,
+                                    // defaultValue: undefined,
+                                    // directives: []
                                 });
                             }
                         });

--- a/packages/data-helper/src/fragments/fragments.utils.js
+++ b/packages/data-helper/src/fragments/fragments.utils.js
@@ -14,7 +14,16 @@ function findParametersInDocument(doc) {
 const queryCache = {};
 
 function replaceFragmentsInDocument(doc, fragments) {
-    const key = doc.definitions[0].name.value + '__' + fragments.map(f => f.gql.definitions[0].name.value).sort().join('_');
+    if (!fragments) {
+        fragments = [];
+    }
+
+    const key = doc.definitions[0].name.value + '__' + fragments
+        .map(f => (typeof f === 'string') ? PredefinedFragments[f] : f)
+        .map(f => f.gql.definitions[0].name.value)
+        .sort()
+        .join('_');
+
     if (queryCache[key]) {
         return queryCache[key];
     }
@@ -93,11 +102,6 @@ function replaceFragmentsInSelectionSet(selectionSet, fragments, def, document) 
                             let existing = _.find(def.variableDefinitions, def => def.variable.name.value === name);
                             if (!existing) {
                                 let type = parseType(value, {noLocation: true});
-                                // delete type.loc;
-                                // delete type.type.loc;
-                                // if (type.type.name) {
-                                //     delete type.type.name.loc;
-                                // }
                                 def.variableDefinitions.push({
                                     kind: 'VariableDefinition',
                                     variable: {
@@ -108,9 +112,6 @@ function replaceFragmentsInSelectionSet(selectionSet, fragments, def, document) 
                                         }
                                     },
                                     type: type
-                                    // ,
-                                    // defaultValue: undefined,
-                                    // directives: []
                                 });
                             }
                         });


### PR DESCRIPTION
## JIRA

https://jira.jahia.org/browse/BACKLOG-12833

## Description

Added a cache for replaceFragmentsInDocument, in order to return the same object when same query/fragments is requested. In some cases, apollo-client is hanging when you reenter the useQuery hook with different query object - even if the query is "similar", it considers the query has changed and seems to get into a loop somewhere. Now it will always get the same query object, so it won't get lost.
I've also changed the name of the returned query so that different queries have different names, which make things more easier when debugging.
This change also enforces even more the fact that every fragment and query in the platform *must* have unique names, as the cache is based on names only. 