### PR TITLE
Update CircleCI configuration related to the NPM registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,17 +44,22 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
+          name: Set registry URL
+          command: npm set registry https://npm.jahia.com/
+      - run:
           name: Authenticate with NPM registry
-          command: echo '//npm.jahia.com/:_authToken=$NPM_TOKEN' >>  `npm config get userconfig`
+          command: echo '//npm.jahia.com/:_authToken=$NPM_TOKEN' >> .npmrc
       - run:
           name: Avoid hosts unknown for github
           command: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config
       - add_ssh_keys:
-                fingerprints:
-                  - "97:b9:c5:2d:c6:80:4b:fd:e4:2c:73:55:49:cf:a9:34"
+          fingerprints:
+            - "97:b9:c5:2d:c6:80:4b:fd:e4:2c:73:55:49:cf:a9:34"
       - run: git config --global user.email "jahia-ci@jahia.com"
       - run: git config --global user.name "JahiaCI"
-      - run: yarn run publish
+      - run: 
+          name: Publish
+          command: yarn run publish
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,10 @@ jobs:
       - attach_workspace:
           at: ./
       - run:
-          name: Set registry URL
-          command: npm set registry https://npm.jahia.com/
-      - run:
           name: Authenticate with NPM registry
-          command: echo '//npm.jahia.com/:_authToken=$NPM_TOKEN' >> .npmrc
+          command: |
+            echo '//npm.jahia.com/:_authToken=$NPM_TOKEN' >> .npmrc
+            cat .npmrc
       - run:
           name: Avoid hosts unknown for github
           command: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,6 +48,8 @@ jobs:
           command: |
             echo '//npm.jahia.com/:_authToken=$NPM_TOKEN' >> .npmrc
             cat .npmrc
+            echo gh=$GH_TOKEN
+            echo npm=$NPM_TOKEN
       - run:
           name: Avoid hosts unknown for github
           command: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config


### PR DESCRIPTION
## Description

This change aims to fix the error "Couldn't publish package: "https://npm.jahia.com/@jahia%2fdata-helper: Request \\"https://npm.jahia.com/@jahia%2fdata-helper\\" returned a 403".

But note that there is still an error with the usage of the Github token ("Went over abuse rate limit GET /repos/:owner/:repo/issues/:issue_number") we are still investigationg on.