### PR TITLE
Fix the issue with the token usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,8 @@ jobs:
       - run:
           name: Authenticate with NPM registry
           command: |
-            echo '//npm.jahia.com/:_authToken=$NPM_TOKEN' >> .npmrc
+            echo "//npm.jahia.com/:_authToken=$NPM_TOKEN" >> .npmrc
             cat .npmrc
-            echo gh=$GH_TOKEN
-            echo npm=$NPM_TOKEN
       - run:
           name: Avoid hosts unknown for github
           command: mkdir ~/.ssh/ && echo -e "Host github.com\n\tStrictHostKeyChecking no\n" > ~/.ssh/config


### PR DESCRIPTION
## Description

This change aims to fix the error "Couldn't publish package: "npm.jahia.com/@jahia%2fdata-helper: Request \"https://npm.jahia.com/@jahia%2fdata-helper\\" returned a 403".