### PR TITLE
BACKLOG-14290: Adds 60% Moonstone Support Colours

### DIFF
--- a/packages/design-system-kit/src/theme/palette.js
+++ b/packages/design-system-kit/src/theme/palette.js
@@ -187,10 +187,13 @@ const dsGenericPalette = {
         support: {
             success: rgba(color.green),
             success40: rgba(color.green, 0.4),
+            success60: rgba(color.green, 0.6),
             warning: rgba(color.yellow),
             warning40: rgba(color.yellow, 0.4),
+            warning60: rgba(color.yellow, 0.6),
             danger: rgba(color.red),
             danger40: rgba(color.red, 0.4),
+            danger60: rgba(color.red, 0.6),
             dangerDark: rgba(color.redDark)
         }
     }

--- a/packages/design-system-kit/src/theme/palette.js
+++ b/packages/design-system-kit/src/theme/palette.js
@@ -186,15 +186,15 @@ const dsGenericPalette = {
         },
         support: {
             success: rgba(color.green),
-            success40: rgba(color.green, 0.4),
             success60: rgba(color.green, 0.6),
+            success40: rgba(color.green, 0.4),
             warning: rgba(color.yellow),
-            warning40: rgba(color.yellow, 0.4),
             warning60: rgba(color.yellow, 0.6),
+            warning40: rgba(color.yellow, 0.4),
+            dangerDark: rgba(color.redDark),
             danger: rgba(color.red),
-            danger40: rgba(color.red, 0.4),
             danger60: rgba(color.red, 0.6),
-            dangerDark: rgba(color.redDark)
+            danger40: rgba(color.red, 0.4)
         }
     }
 };


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-14290

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

* Added 60% opacity Moonstone support colour to @jahia/design-system-kit colour palette