### PR TITLE
BACKLOG-14306: Removed reset-state

### DIFF
--- a/packages/ui-extender/src/actions/menuAction/menuAction.jsx
+++ b/packages/ui-extender/src/actions/menuAction/menuAction.jsx
@@ -171,7 +171,8 @@ const reducer = (state, action) => {
         case 'loading':
             return {
                 ...state,
-                loadingItems: add(state.loadingItems, action.item)
+                loadingItems: add(state.loadingItems, action.item),
+                loadedItems: remove(state.loadedItems, action.item)
             };
         case 'loaded':
             return {

--- a/packages/ui-extender/src/actions/menuAction/menuAction.jsx
+++ b/packages/ui-extender/src/actions/menuAction/menuAction.jsx
@@ -2,7 +2,6 @@ import React, {useEffect, useMemo, useReducer, useRef} from 'react';
 import ReactDOM from 'react-dom';
 import PropTypes from 'prop-types';
 import {DisplayActions} from '../core/DisplayActions';
-import {useDeepCompare} from '../../utils/useDeepCompare';
 
 const ItemLoading = ({context}) => {
     const {parentMenuContext, menuItemRenderer: MenuItemRenderer} = context;
@@ -180,12 +179,6 @@ const reducer = (state, action) => {
                 loadingItems: remove(state.loadingItems, action.item),
                 loadedItems: action.isVisible !== false ? add(state.loadedItems, action.item) : remove(state.loadedItems, action.item)
             };
-        case 'resetState':
-            return {
-                ...state,
-                loadingItems: [],
-                loadedItems: []
-            };
         default:
             return state;
     }
@@ -194,8 +187,6 @@ const reducer = (state, action) => {
 const MenuActionComponent = ({context, render: Render, loading: Loading}) => {
     const id = 'actionComponent-' + context.id;
     const {rootMenuContext, parentMenuContext} = context;
-
-    const {isNew, isChanged, value: stableOriginalContext} = useDeepCompare(context.originalContext);
 
     const elRef = useRef(document.getElementById('menuHolder'));
     if (!elRef.current) {
@@ -238,13 +229,6 @@ const MenuActionComponent = ({context, render: Render, loading: Loading}) => {
             }, 0);
         }
     }), [id, parentMenuContext]);
-
-    useEffect(() => {
-        if (!isNew && isChanged) {
-            // Reset loading state if context has changed
-            dispatch({type: 'resetState'});
-        }
-    }, [isNew, isChanged, stableOriginalContext]);
 
     useEffect(() => {
         if (!menuState.isOpen && menuState.subMenuContext) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-14306

## Description

Reset-state and deep-compare were needed when we were using the component renderer, to correctly update the props when needed. Now rendering is directly handled by react portal which takes care of the comparison, deep-compare is not needed anymore and reset state does not seem to be useful neither.
This was introduced to correctly handle the change in context, resetting the loading states of every item in the menu.