### PR TITLE
BACKLOG-14368: Stop propagation after menu item click

### DIFF
--- a/packages/ui-extender/src/actions/menuAction/menuAction.jsx
+++ b/packages/ui-extender/src/actions/menuAction/menuAction.jsx
@@ -38,6 +38,7 @@ const ItemRender = ({context}) => {
                           onClick={event => {
                               // Call the action and close the menu
                               context.onClick(context, event);
+                              event.stopPropagation();
                               rootMenuContext.dispatch({type: 'close'});
                           }}
                           onMouseEnter={event => {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-14368

## Description

Since the menu is not rendered with the component renderer it seems the click event is propagated to the tree element, even though the menu is not in the same part of the dom .. stopPropagation() prevent it.