### PR TITLE
BACKLOG-14270 : Menu action fixes

### DIFF
--- a/packages/ui-extender/src/actions/core/DisplayAction.jsx
+++ b/packages/ui-extender/src/actions/core/DisplayAction.jsx
@@ -4,15 +4,6 @@ import {registry} from '../../registry';
 
 let count = 0;
 
-const arrayEquals = (array1, array2) =>
-    Array.isArray(array1) && Array.isArray(array2) && array1.length === array2.length && array1.every((value, index) => shallowEquals(value, array2[index]));
-
-const shallowEquals = (obj1, obj2) =>
-    Object.keys(obj1).length === Object.keys(obj2).length &&
-    Object.keys(obj1)
-        .filter(key => (typeof obj1[key] !== 'function') && (typeof obj1[key] !== 'object' || Array.isArray(obj1[key])))
-        .every(key => Array.isArray(obj1[key]) ? arrayEquals(obj1[key], obj2[key]) : obj1[key] === obj2[key]);
-
 const wrapRender = render => ({context, ...otherProps}) => {
     const mergedProps = {...context, ...otherProps};
     return render({...mergedProps, context: mergedProps});
@@ -22,10 +13,6 @@ class DisplayAction extends React.Component {
     constructor(props) {
         super(props);
         this.id = props.actionKey + '-' + (count++);
-    }
-
-    shouldComponentUpdate(nextProps) {
-        return !shallowEquals(nextProps, this.props);
     }
 
     render() {

--- a/packages/ui-extender/src/actions/menuAction/menuAction.jsx
+++ b/packages/ui-extender/src/actions/menuAction/menuAction.jsx
@@ -46,8 +46,11 @@ const ItemRender = ({context, ...otherProps}) => {
                               if (menuContext) {
                                   // Open submenu (only if it's not opened already)
                                   if (!menuState.isOpen) {
+                                      const c = event.currentTarget.getBoundingClientRect();
                                       menuContext.display(null, {
-                                          anchorEl: event.currentTarget,
+                                          anchorEl: {
+                                              getBoundingClientRect: () => c
+                                          },
                                           anchorElOrigin: {vertical: 'top', horizontal: 'right'}
                                       });
                                   }
@@ -173,13 +176,13 @@ const reducer = (state, action) => {
         }
 
         case 'loading':
-            return {
+            return (state.loadingItems.includes(action.item) && !state.loadedItems.includes(action.item)) ? state : {
                 ...state,
                 loadingItems: add(state.loadingItems, action.item),
                 loadedItems: remove(state.loadedItems, action.item)
             };
         case 'loaded':
-            return {
+            return (!state.loadingItems.includes(action.item) && (action.isVisible !== false) === state.loadedItems.includes(action.item)) ? state : {
                 ...state,
                 loadingItems: remove(state.loadingItems, action.item),
                 loadedItems: action.isVisible !== false ? add(state.loadedItems, action.item) : remove(state.loadedItems, action.item)

--- a/packages/ui-extender/src/actions/menuAction/menuAction.spec.jsx
+++ b/packages/ui-extender/src/actions/menuAction/menuAction.spec.jsx
@@ -77,7 +77,7 @@ const AsyncComponent = ({context, render: Render, loading: Loading}) => {
         return () => {
             clearTimeout(t);
         };
-    });
+    }, []);
     if (!ready && readyList.indexOf(context.key) === -1) {
         if (context.useLoading && Loading) {
             return <Loading context={context}/>;


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

- Removed shouldComponentUpdate optimization to solve ContentEditor issue ( BACKLOG-14585 )
- Fixed infinite render loop in menu by avoid resetting a state when no value has changed
- Copy target element position for menu item as it gets remove/recreated when shouldComponentUpdate returns true
