### PR TITLE
Removes .npmrc and updates README

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-@jahia:registry=https://npm.jahia.com

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Ensure that you're logged into the Jahia organization on the *public* npm regist
 npm set registry https://registry.npmjs.org/
 npm adduser --registry https://registry.npmjs.org/
 ```
-You can request a Jahia organization npm account from IT.
+You can request an npm account for the Jahia organization from IT.
 
 Ensure that your `node_modules` are up to date for the javascript-components repo as a whole and for the specific package you want to publish.
 

--- a/README.md
+++ b/README.md
@@ -100,12 +100,12 @@ NPM_TOKEN=xxx
 ```
 They can be set in your environment or in a `.env` file.
 
-Ensure that the Jahia npm registry is configured:
+Ensure that you're logged into the Jahia organization on the *public* npm registry:
 ```
-npm set registry https://npm.jahia.com
-npm adduser --registry https://npm.jahia.com
+npm set registry https://registry.npmjs.org/
+npm adduser --registry https://registry.npmjs.org/
 ```
-You'll find the npm user credentials at it.jahia.com (make sure you're on VPN and sign in with your LDAP credentials).
+You can request a Jahia organization npm account from IT.
 
 Ensure that your `node_modules` are up to date for the javascript-components repo as a whole and for the specific package you want to publish.
 


### PR DESCRIPTION
Guild Day Oct. 28, 2020:
* Removes .npmrc to remove the connection between these packages and the Jahia npm registry
* Updates README.md to reflect the process to publish the packages to the public npm registry