### PR TITLE
TECH-529: Improved performances

### DIFF
--- a/packages/ui-extender/src/actions/core/DisplayAction.jsx
+++ b/packages/ui-extender/src/actions/core/DisplayAction.jsx
@@ -9,7 +9,7 @@ const wrapRender = render => ({context, ...otherProps}) => {
     return render({...mergedProps, context: mergedProps});
 };
 
-class DisplayAction extends React.Component {
+class DisplayAction extends React.PureComponent {
     constructor(props) {
         super(props);
         this.id = props.actionKey + '-' + (count++);

--- a/packages/ui-extender/src/actions/menuAction/menuAction.jsx
+++ b/packages/ui-extender/src/actions/menuAction/menuAction.jsx
@@ -117,7 +117,6 @@ const Menu = props => {
                             filter={menuFilter}
                             buttonProps={menuItemProps}
                             menuRenderer={MenuRenderer}
-                            menuState={menuState}
                             menuItemRenderer={menuItemRenderer}
                             parentMenuContext={menuContext}
                             rootMenuContext={rootMenuContext}


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/TECH-529

## Description

Use PureComponent to memoize DisplayAction rendering, when no prop is changed.
Remove menuState from DisplayAction props, which is not used and cause full re-render of all subcomponents