### PR TITLE
BACKLOG-19919: Use descendants and recursion filter for useTreeEntries

### DIFF
--- a/packages/data-helper/src/fragments/fragments.utils.js
+++ b/packages/data-helper/src/fragments/fragments.utils.js
@@ -5,7 +5,7 @@ import {PredefinedFragments} from '../fragments';
 
 function findParametersInDocument(doc) {
     if (doc && doc.definitions) {
-        return _.flatMap(doc.definitions, def => findParametersInSelectionSet(def.selectionSet));
+        return doc.definitions.flatMap(def => findParametersInSelectionSet(def.selectionSet));
     }
 
     return [];
@@ -31,7 +31,7 @@ function replaceFragmentsInDocument(doc, fragments) {
     let clonedQuery = null;
     if (doc && doc.definitions) {
         clonedQuery = _.cloneDeep(doc);
-        _.each(clonedQuery.definitions, def => replaceFragmentsInSelectionSet(def.selectionSet, fragments, def, clonedQuery));
+        clonedQuery.definitions.forEach(def => replaceFragmentsInSelectionSet(def.selectionSet, fragments, def, clonedQuery));
         clonedQuery.definitions[0].name.value = key;
     }
 
@@ -42,10 +42,10 @@ function replaceFragmentsInDocument(doc, fragments) {
 
 function findParametersInSelectionSet(selectionSet) {
     if (selectionSet && selectionSet.selections) {
-        return _.flatMap(selectionSet.selections, sel =>
-            _.without(_.concat(
-                _.flatMap(_.filter(sel.arguments, arg => (arg.value.kind === 'Variable')), arg => arg.value.name.value),
-                findParametersInSelectionSet(sel.selectionSet)), undefined)
+        return selectionSet.selections.flatMap(sel =>
+            sel.arguments.filter(arg => (arg.value.kind === 'Variable')).flatMap(arg => arg.value.name.value)
+                .concat(findParametersInSelectionSet(sel.selectionSet))
+                .filter(f => typeof f !== 'undefined')
         );
     }
 
@@ -54,9 +54,8 @@ function findParametersInSelectionSet(selectionSet) {
 
 function findFragmentsInSelectionSet(selectionSet) {
     if (selectionSet && selectionSet.selections) {
-        return _.concat(
-            _.map(_.filter(selectionSet.selections, sel => sel.kind === 'FragmentSpread'), sel => sel.name.value),
-            _.flatMap(selectionSet.selections, sel => findFragmentsInSelectionSet(sel.selectionSet)));
+        return selectionSet.selections.filter(sel => sel.kind === 'FragmentSpread').map(sel => sel.name.value)
+            .concat(selectionSet.selections.flatMap(sel => findFragmentsInSelectionSet(sel.selectionSet)));
     }
 
     return [];
@@ -67,11 +66,11 @@ function replaceFragmentsInSelectionSet(selectionSet, fragments, def, document) 
         let newFragmentsSpreads = [];
         let removedFragmentSpreads = [];
         // Look for all existing fragment spreads in selection set
-        _.each(_.filter(selectionSet.selections, sel => sel.kind === 'FragmentSpread'), sel => {
+        selectionSet.selections.filter(sel => sel.kind === 'FragmentSpread').forEach(sel => {
             // Handle only named fragments
             if (sel.name.value) {
                 // Check if spread exists in current doc - if not, we replace or remove it
-                let existing = _.find(document.definitions, definition => definition.kind === 'FragmentDefinition' && definition.name.value === sel.name.value);
+                let existing = document.definitions.find(definition => definition.kind === 'FragmentDefinition' && definition.name.value === sel.name.value);
 
                 if (!existing) {
                     // First remove the spread, as it has no match in document
@@ -79,27 +78,26 @@ function replaceFragmentsInSelectionSet(selectionSet, fragments, def, document) 
 
                     // Check if a replacement is provided for this pseudo-fragment, then insert spreads and definitions
                     if (fragments) {
-                        fragments = _.map(fragments, frag => (typeof frag === 'string') ? PredefinedFragments[frag] : frag);
+                        fragments = fragments.map(frag => (typeof frag === 'string') ? PredefinedFragments[frag] : frag);
 
-                        let applyableFragments = _.filter(fragments, frag => frag.applyFor === sel.name.value);
+                        const applyableFragments = fragments.filter(frag => frag.applyFor === sel.name.value);
 
-                        let allFragmentsDefinitions = _.flatMap(applyableFragments, fragment => fragment.gql.definitions);
-                        _.each(allFragmentsDefinitions, frag => {
-                            let newSpread = _.cloneDeep(sel);
+                        applyableFragments.flatMap(fragment => fragment.gql.definitions).forEach(frag => {
+                            const newSpread = _.cloneDeep(sel);
                             newSpread.name.value = frag.name.value;
                             newFragmentsSpreads.push(newSpread);
 
                             // Add the new fragment definition in document if it has not already been added
-                            let existing = _.find(document.definitions, definition => definition.kind === 'FragmentDefinition' && definition.name.value === frag.name.value);
+                            let existing = document.definitions.find(definition => definition.kind === 'FragmentDefinition' && definition.name.value === frag.name.value);
                             if (!existing) {
                                 document.definitions.push(frag);
                             }
                         });
 
                         // Adds the associated variables to the query
-                        let allVariables = _.reduce(applyableFragments, (result, n) => _.assign(result, n.variables), {});
-                        _.each(allVariables, (value, name) => {
-                            let existing = _.find(def.variableDefinitions, def => def.variable.name.value === name);
+                        let allVariables = applyableFragments.reduce((result, n) => ({...result, ...n.variables}), {});
+                        Object.entries(allVariables).forEach(([name, value]) => {
+                            let existing = def.variableDefinitions.find(def => def.variable.name.value === name);
                             if (!existing) {
                                 let type = parseType(value, {noLocation: true});
                                 def.variableDefinitions.push({
@@ -121,13 +119,13 @@ function replaceFragmentsInSelectionSet(selectionSet, fragments, def, document) 
         });
 
         // Removed replaced spreads
-        selectionSet.selections = _.filter(selectionSet.selections, sel => removedFragmentSpreads.indexOf(sel) === -1);
+        selectionSet.selections = selectionSet.selections.filter(sel => removedFragmentSpreads.indexOf(sel) === -1);
 
         // Add all new spreads
         selectionSet.selections.push(...newFragmentsSpreads);
 
         // Recursively call on sub-selections set
-        _.each(selectionSet.selections, sel => replaceFragmentsInSelectionSet(sel.selectionSet, fragments, def, document));
+        selectionSet.selections.forEach(sel => replaceFragmentsInSelectionSet(sel.selectionSet, fragments, def, document));
     }
 }
 

--- a/packages/data-helper/src/hooks/useTreeEntries/useTreeEntries.gql-queries.js
+++ b/packages/data-helper/src/hooks/useTreeEntries/useTreeEntries.gql-queries.js
@@ -1,13 +1,12 @@
-// TODO BACKLOG-12393 - refactor Legacy Picker into hook without lodash
 import gql from 'graphql-tag';
 import {nodeCacheRequiredFields} from '../../fragments/PredefinedFragments';
 
 export const TREE_QUERY = gql`
-    query PickerQuery($rootPaths:[String!]!, $selectable:[String]!, $openable:[String]!, $openPaths:[String!]!, $types:[String]!, $sortBy: InputFieldSorterInput) {
+    query PickerQuery($rootPaths:[String!]!, $selectable:[String]!, $openable:[String]!, $openPaths:[String!]!, $types:[String]!, $recursionTypesFilter: InputNodeTypesInput, $sortBy: InputFieldSorterInput, $fieldGrouping: InputFieldGroupingInput) {
         jcr {
             rootNodes:nodesByPath(paths: $rootPaths) {
                 name
-                children(typesFilter:{types:$types}, limit:1) {
+                children: descendants(typesFilter:{types: $types}, recursionTypesFilter: $recursionTypesFilter, limit:1) {
                     pageInfo {
                         nodesCount
                     }
@@ -19,10 +18,10 @@ export const TREE_QUERY = gql`
             },
             openNodes:nodesByPath(paths: $openPaths) {
                 ... NodeCacheRequiredFields
-                children(typesFilter:{types:$types}, fieldSorter: $sortBy) {
+                children:descendants(typesFilter:{types: $types}, recursionTypesFilter: $recursionTypesFilter, fieldSorter: $sortBy, fieldGrouping: $fieldGrouping) {
                     nodes {
                         name
-                        children(typesFilter:{types:$types}, limit:1) {
+                        children: descendants(typesFilter:{types: $types}, recursionTypesFilter: $recursionTypesFilter, limit:1) {
                             pageInfo {
                                 nodesCount
                             }

--- a/packages/data-helper/src/hooks/useTreeEntries/useTreeEntries.js
+++ b/packages/data-helper/src/hooks/useTreeEntries/useTreeEntries.js
@@ -75,7 +75,7 @@ export const useTreeEntries = ({
 
     let vars = {
         rootPaths: rootPaths,
-        types: Array.from(new Set([...openableTypes, ...selectableTypes])),
+        types: Array.from(new Set([...(openableTypes || []), ...(selectableTypes || [])])),
         recursionTypesFilter: recursionTypesFilter || {types: 'nt:base', multi: 'NONE'},
         selectable: selectableTypes,
         openable: openableTypes,

--- a/packages/data-helper/src/hooks/useTreeEntries/useTreeEntries.js
+++ b/packages/data-helper/src/hooks/useTreeEntries/useTreeEntries.js
@@ -2,7 +2,6 @@ import {useRef} from 'react';
 import {useQuery} from 'react-apollo';
 import {replaceFragmentsInDocument} from '../../fragments/fragments.utils';
 import {TREE_QUERY} from './useTreeEntries.gql-queries';
-import * as _ from 'lodash';
 
 export const useTreeEntries = ({
     fragments,
@@ -11,6 +10,7 @@ export const useTreeEntries = ({
     selectedPaths,
     openableTypes,
     selectableTypes,
+    recursionTypesFilter,
     queryVariables,
     hideRoot,
     sortBy
@@ -18,25 +18,25 @@ export const useTreeEntries = ({
     let query = useRef(replaceFragmentsInDocument(TREE_QUERY, fragments));
 
     const getTreeEntries = (data, selectedPaths, openPaths) => {
-        let treeEntries = [];
-        let nodesById = {};
-        let jcr = data ? data.jcr : {};
+        const treeEntries = [];
+        const nodesById = {};
+        const jcr = data ? data.jcr : {};
 
-        let addNode = function (node, depth, index) {
+        const addNode = function (node, depth, index) {
             let selected = false;
             if (node.selectable) {
-                selected = _.indexOf(selectedPaths, node.path) !== -1;
+                selected = selectedPaths.indexOf(node.path) !== -1;
             }
 
             let treeEntry = {
                 name: node.name,
                 path: node.path,
-                open: node.openable && _.indexOf(openPaths, node.path) !== -1,
+                open: node.openable && openPaths.indexOf(node.path) !== -1,
                 selected: selected,
                 openable: node.openable,
                 selectable: node.selectable,
                 depth: depth,
-                prefix: _.repeat('&nbsp;', depth * 3),
+                prefix: '&nbsp;'.repeat(depth * 3),
                 node: node,
                 hidden: false,
                 hasChildren: node.children.pageInfo.nodesCount > 0
@@ -48,18 +48,18 @@ export const useTreeEntries = ({
 
         if (jcr) {
             if (jcr.rootNodes) {
-                _.forEach(jcr.rootNodes, rootNode => {
+                jcr.rootNodes.forEach(rootNode => {
                     let root = addNode(rootNode, 0, 0);
                     root.hidden = hideRoot;
                 });
             }
 
             if (jcr.openNodes) {
-                _.sortBy(jcr.openNodes, ['path']).forEach(node => {
-                    let parent = nodesById[node.uuid];
+                [...jcr.openNodes].sort((a, b) => a.path.localeCompare(b.path)).forEach(node => {
+                    const parent = nodesById[node.uuid];
                     if (parent) {
-                        let parentIndex = _.indexOf(treeEntries, parent);
-                        _.forEachRight(node.children.nodes, child => {
+                        const parentIndex = treeEntries.indexOf(parent);
+                        [...node.children.nodes].reverse().forEach(child => {
                             addNode(child, parent.depth + 1, parentIndex + 1);
                         });
                     }
@@ -68,35 +68,21 @@ export const useTreeEntries = ({
         }
 
         // Nodes loaded, fill selection list
-        let selectedNodes = _.filter(treeEntries, node => {
-            return node.selected;
-        }).map(node => {
-            return node.node;
-        });
+        selectedPaths = treeEntries.filter(node => node.selected).map(node => node.node.path);
 
-        selectedPaths = _.map(selectedNodes, 'path');
-        treeEntries = _.filter(treeEntries, treeNode => {
-            return !treeNode.hidden;
-        });
-
-        return treeEntries;
+        return treeEntries.filter(treeNode => !treeNode.hidden);
     };
 
     let vars = {
         rootPaths: rootPaths,
-        types: _.union(openableTypes, selectableTypes),
+        types: Array.from(new Set([...openableTypes, ...selectableTypes])),
+        recursionTypesFilter: recursionTypesFilter || {types: 'nt:base', multi: 'NONE'},
         selectable: selectableTypes,
         openable: openableTypes,
-        openPaths: openPaths
+        openPaths: openPaths,
+        sortBy,
+        ...queryVariables
     };
-
-    if (sortBy) { // Add the sortBy if it is not null or undefined
-        vars.sortBy = sortBy;
-    }
-
-    if (queryVariables) {
-        _.assign(vars, queryVariables);
-    }
 
     const {data, ...others} = useQuery(query.current, {...queryOptions, variables: vars});
     return {treeEntries: getTreeEntries(data, selectedPaths, openPaths), ...others};


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-19919

## Description

The `descendants` without recursionTypesFilter specified will give the same result as children, as it will use by default `{types: 'nt:base', multi: 'NONE'}` (recurse on nothing)
Also replaced lodash usage by standard js
