### PR TITLE
BACKLOG-20903 Add possibility to determine visibility 

### DIFF
--- a/packages/ui-extender/src/actions/menuAction/menuAction.jsx
+++ b/packages/ui-extender/src/actions/menuAction/menuAction.jsx
@@ -247,7 +247,6 @@ const MenuActionComponent = props => {
     const menuContext = useMemo(() => ({
         id,
         dispatch,
-        menuState,
         display: (currentCtx, anchor) => {
             dispatch({type: 'render', currentCtx});
             // If there's a parent, set the current context as submenu. Previous value should be null
@@ -260,7 +259,7 @@ const MenuActionComponent = props => {
                 dispatch({type: 'open', anchor});
             }, 0);
         }
-    }), [id, parentMenuContext, menuState, dispatch]);
+    }), [id, parentMenuContext]);
 
     useEffect(() => {
         if (!menuState.isOpen && menuState.subMenuContext) {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-20903 

## Description

Allow to pass predicate function which takes menuState as param and can help determine if action component is visible or not.

In jContent I have a function which checks if I have loaded items other than the two labels I expect to always be there.