### PR TITLE
BACKLOG-21054: Fix legacy picker for vanity urls

### DIFF
--- a/packages/data-helper/src/legacy/Picker.tsx
+++ b/packages/data-helper/src/legacy/Picker.tsx
@@ -346,7 +346,7 @@ export class Picker extends React.Component<PropType, StateType> {
 
     render() {
         const selectedPaths = this.state.selectedPaths ? this.state.selectedPaths : this.props.selectedPaths;
-        let openPaths = this.state.openPaths || this.props.openPaths || this.props.defaultOpenPaths;
+        let openPaths = this.state.openPaths || this.props.openPaths;
         const {setRefetch} = this.props;
 
         openPaths = clone(openPaths);

--- a/packages/data-helper/src/legacy/Picker.tsx
+++ b/packages/data-helper/src/legacy/Picker.tsx
@@ -149,7 +149,7 @@ export class Picker extends React.Component<PropType, StateType> {
 
         this.eventsHandlers = {};
 
-        if (openPaths === null) {
+        if (!openPaths) {
             // Uncontrolled mode
             state.isOpenControlled = false;
             state.openPaths = [];
@@ -171,7 +171,7 @@ export class Picker extends React.Component<PropType, StateType> {
             }
         }
 
-        if (selectedPaths === null) {
+        if (!selectedPaths) {
             // Uncontrolled mode
             state.isSelectControlled = false;
             state.selectedPaths = defaultSelectedPaths ? clone(defaultSelectedPaths) : [];
@@ -205,7 +205,7 @@ export class Picker extends React.Component<PropType, StateType> {
     }
 
     static getDerivedStateFromProps(nextProps: PropType, prevState: StateType) {
-        if ((prevState.isOpenControlled !== (nextProps.openPaths !== null)) || (prevState.isSelectControlled !== (nextProps.selectedPaths !== null))) {
+        if ((prevState.isOpenControlled !== Boolean(nextProps.openPaths)) || (prevState.isSelectControlled !== Boolean(nextProps.selectedPaths))) {
             console.warn('Cannot change between controlled/uncontrolled modes');
         }
 
@@ -346,7 +346,7 @@ export class Picker extends React.Component<PropType, StateType> {
 
     render() {
         const selectedPaths = this.state.selectedPaths ? this.state.selectedPaths : this.props.selectedPaths;
-        let openPaths = this.state.openPaths ? this.state.openPaths : this.props.openPaths;
+        let openPaths = this.state.openPaths || this.props.openPaths || this.props.defaultOpenPaths;
         const {setRefetch} = this.props;
 
         openPaths = clone(openPaths);


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21054

All null checks are now returning undefined after data-helper upgrade, so we have to adjust the checks to falsy values instead.

~~Also openPaths missing on init is now causing issue on cached query and throwing error. Needed to add a default value to fix.~~ Edit: Not needed as this was being set here: https://github.com/Jahia/javascript-components/blob/master/packages/data-helper/src/legacy/Picker.tsx#L165 but was being blocked by the null checks issue which was already fixed.
