### PR TITLE
BACKLOG-23042 Add delayed deploy to prevent concurrency error

### DIFF
--- a/packages/scripts/deploy.js
+++ b/packages/scripts/deploy.js
@@ -3,6 +3,28 @@ require('dotenv').config();
 const {execSync} = require('child_process');
 const pack = require('./pack-project');
 const fs = require('fs');
+const path = require('path');
+
+// Delay before redeploying in milliseconds :
+const delayReDeploy = 5000;
+const timestampFilePath = path.resolve(__dirname, 'lastDeployTimestamp.txt');
+
+function shouldRunDeploy() {
+    try {
+        const lastDeploy = fs.readFileSync(timestampFilePath, 'utf-8');
+        const now = Date.now();
+
+        if (now - parseInt(lastDeploy, 10) >= delayReDeploy) {
+            fs.writeFileSync(timestampFilePath, now.toString());
+            return true;
+        }
+    } catch (error) {
+        // If the timestamp file doesn't exist or an error is thrown, we update the timestamp and return true to deploy
+        fs.writeFileSync(timestampFilePath, Date.now().toString());
+        return true;
+    }
+    return false;
+}
 
 const args = process.argv.slice(2);
 const deployMethod = process.env.JAHIA_DEPLOY_METHOD;
@@ -17,10 +39,15 @@ if (!fs.existsSync(packageFileName)) {
     pack();
 }
 
-if (deployMethod === 'curl') {
-    console.log('Deploying URL curl to Jahia bundles REST API...');
-    console.log(execSync(`curl -s --user ${process.env.JAHIA_USER} --form bundle=@./${packageFileName} --form start=true ${process.env.JAHIA_HOST}/modules/api/bundles`, {encoding: 'utf8'}));
+// Deploy is delayed to prevent concurrency error on the backend (jcr InvalidItemStateException)
+if (shouldRunDeploy()) {
+    if (deployMethod === 'curl') {
+        console.log('Deploying URL curl to Jahia bundles REST API...');
+        console.log(execSync(`curl -s --user ${process.env.JAHIA_USER} --form bundle=@./${packageFileName} --form start=true ${process.env.JAHIA_HOST}/modules/api/bundles`, {encoding: 'utf8'}));
+    } else {
+        console.log('Deploying using Docker copy...');
+        console.log(execSync(`docker cp ${packageFileName} ${process.env.JAHIA_DOCKER_NAME}:/var/jahia/modules`, {encoding: 'utf8'}));
+    }
 } else {
-    console.log('Deploying using Docker copy...');
-    console.log(execSync(`docker cp ${packageFileName} ${process.env.JAHIA_DOCKER_NAME}:/var/jahia/modules`, {encoding: 'utf8'}));
+    console.log('Module not deployed, precedent module deployment is not finished.');
 }


### PR DESCRIPTION
https://jira.jahia.org/browse/BACKLOG-23042

Added a shouldRunDeploy function that doesn't deploy the module if a precedent watch deployment is ongoing (timeout is setted to 5 sec by default, configurable in the script), maybe making this delay configurable with a parameter would be better ? 
For exemple we could run the command like that instead : 'yarn jahia-pack --delay=3000' 

The function store a timestamp in a lastDeployTimestamp.txt file at the root of the project.


## Tests 

Pull and run module, luxe for example, and make quick changes successively, for example add a newLine in a file, save to start the building, make another changes and saves again.

If you see this log line, the deployment got delayed : 

`Module not deployed, precedent module deployment is not finished`
