### PR TITLE
BACKLOG-23059 Added `lockInfo` to node info query

### DIFF
--- a/packages/data-helper/src/fragments/PredefinedFragments.ts
+++ b/packages/data-helper/src/fragments/PredefinedFragments.ts
@@ -161,6 +161,16 @@ export const lockInfo: Fragment = {
     }`
 };
 
+export const canLockUnlock: Fragment = {
+    applyFor: 'node',
+    gql: gql`fragment CanLockUnlockInfo on JCRNode {
+        lockInfo {
+            canLock,
+            canUnlock,
+        }
+    }`
+};
+
 export const subNodesCount: Fragment = {
     variables: {
         subNodesCountTypes: '[String!]!'

--- a/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.ts
+++ b/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.ts
@@ -2,6 +2,7 @@ import gql from 'graphql-tag';
 import {
     aggregatedPublicationInfo,
     aggregatedPublicationInfoWithExistInLive,
+    canLockUnlock,
     childNodeTypes,
     contentRestrictions,
     displayableNode,
@@ -135,6 +136,7 @@ export type NodeInfoOptions = Partial<{
     getSiteLanguages: boolean,
     getDisplayableNodePath: boolean,
     getLockInfo: boolean,
+    getCanLockUnlock: boolean,
     getChildNodeTypes: boolean,
     getContributeTypesRestrictions: boolean,
     getSubNodesCount: string[],
@@ -156,6 +158,7 @@ export const validOptions = [
     'getSiteLanguages',
     'getDisplayableNodePath',
     'getLockInfo',
+    'getCanLockUnlock',
     'getChildNodeTypes',
     'getContributeTypesRestrictions',
     'getSubNodesCount',
@@ -263,6 +266,10 @@ export const getQuery = (variables: {[key:string]: any}, schemaResult: any, opti
 
         if (options.getLockInfo) {
             fragments.push(lockInfo);
+        }
+
+        if (options.getCanLockUnlock) {
+            fragments.push(canLockUnlock);
         }
 
         if (options.getChildNodeTypes) {

--- a/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.test.js
+++ b/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.test.js
@@ -188,6 +188,22 @@ describe('useNodeInfo', () => {
         expect(result.value.query.definitions.find(d => d.name.value === 'NodeProperties').selectionSet.selections.map(m => m.name.value)).toContain('properties');
     });
 
+    it('should request can lock unlock info', async () => {
+        const setStateMock = jest.fn();
+        const useStateMock = useState => [useState, setStateMock];
+        jest.spyOn(React, 'useState').mockImplementation(useStateMock);
+        useNodeInfo({path: '/test', language: 'en'}, {getCanLockUnlock: true});
+
+        await wait();
+
+        expect(getQuery).toHaveBeenCalled();
+        const {mock} = getQuery;
+        const result = mock.results[mock.results.length - 1];
+        const variables = result.value.generatedVariables;
+        result.value.query.definitions[0].variableDefinitions.map(v => v.variable.name.value).forEach(v => expect(Object.keys(variables)).toContain(v));
+        expect(result.value.query.definitions.map(d => d.name.value)).toContain('CanLockUnlockInfo');
+    });
+
     it('should request all data', async () => {
         const setStateMock = jest.fn();
         const useStateMock = useState => [useState, setStateMock];
@@ -205,6 +221,7 @@ describe('useNodeInfo', () => {
             getSiteLanguages: true,
             getDisplayableNodePath: true,
             getLockInfo: true,
+            getCanLockUnlock: true,
             getContributeTypesRestrictions: true,
             getSubNodesCount: ['jnt:file'],
             getMimeType: true


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23059

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

This PR adds some missing lockInfo fields to node info query.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
