### PR TITLE
Update pack and deploy to generate the archive in /dist and to deploy…

### DIFF
--- a/packages/scripts/deploy.js
+++ b/packages/scripts/deploy.js
@@ -7,9 +7,9 @@ const fs = require('fs');
 const args = process.argv.slice(2);
 const deployMethod = process.env.JAHIA_DEPLOY_METHOD;
 const cleanPackageName = process.env.npm_package_name.replace(/@/g, '').replace(/\//g, '-');
-const packageFileName = `${cleanPackageName}-v${process.env.npm_package_version}.tgz`;
+const packageFilePath = `/dist/${cleanPackageName}-v${process.env.npm_package_version}.tgz`;
 
-if (!fs.existsSync(packageFileName)) {
+if (!fs.existsSync(packageFilePath)) {
     console.log('Package hasn\'t been built previously, packing now using jahia-pack...');
     pack();
 } else if (args.length > 0 && args[0] === 'pack') {
@@ -19,8 +19,8 @@ if (!fs.existsSync(packageFileName)) {
 
 if (deployMethod === 'curl') {
     console.log('Deploying URL curl to Jahia bundles REST API...');
-    console.log(execSync(`curl -s --user ${process.env.JAHIA_USER} --form bundle=@./${packageFileName} --form start=true ${process.env.JAHIA_HOST}/modules/api/bundles`, {encoding: 'utf8'}));
+    console.log(execSync(`curl -s --user ${process.env.JAHIA_USER} --form bundle=@./${packageFilePath} --form start=true ${process.env.JAHIA_HOST}/modules/api/bundles`, {encoding: 'utf8'}));
 } else {
     console.log('Deploying using Docker copy...');
-    console.log(execSync(`docker cp ${packageFileName} ${process.env.JAHIA_DOCKER_NAME}:/var/jahia/modules`, {encoding: 'utf8'}));
+    console.log(execSync(`docker cp ${packageFilePath} ${process.env.JAHIA_DOCKER_NAME}:/var/jahia/modules`, {encoding: 'utf8'}));
 }

--- a/packages/scripts/pack-project.js
+++ b/packages/scripts/pack-project.js
@@ -12,7 +12,7 @@ function pack() {
         console.log(execSync('yarn pack', {encoding: 'utf8'}));
     } else if (semver.gte(yarnVersion, '2.0.0')) {
         console.log('Yarn Berry detected');
-        console.log(execSync(`yarn pack --out ${cleanPackageName}-v${process.env.npm_package_version}.tgz`, {encoding: 'utf8'}));
+        console.log(execSync(`yarn pack --out  /dist/${cleanPackageName}-v${process.env.npm_package_version}.tgz`, {encoding: 'utf8'}));
     }
 }
 


### PR DESCRIPTION
In pack-deploy, generate the tgz inside the dist folder instead of the root folder

In deploy, get the tgz from the dist folder instead of the root folder.


## Tests : 

- Pack any project with the command 'yarn jahia-pack', the tgz should be in the dist folder
- Deploy the project with the command 'yarn jahia-pack', the deploy should work 