### PR TITLE
SEC-104: Remove usage of introspection query SCHEMA_FIELDS_QUERY

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,18 @@ Run `yarn build`.
 
 Run `yarn publish-script` in the package that you want to publish. Be sure to stop the CircleCI build to avoid the creation of unnecessary branches, etc.
 
+## Manual publish 
+
+Prerequisites: 
+
+* npm publish permissions
+* Verify version to be published is reflected in package.json for the current branch to be published
+
+1. In root `javascript-components` folder: `rm -rf node_modules`
+2. go to the package to be deployed e.g. `cd packages/data-helper`
+3. Run `yarn build`
+4. Run `cd build; npm publish --tag ${tag}` where `${tag}` is replaced by the version tag, e.g. `npm publish --tag 1.0`
+
 ## Author
 
 👤 **Jahia Group**

--- a/packages/data-helper/package.json
+++ b/packages/data-helper/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jahia/data-helper",
-  "version": "1.0.9",
+  "version": "1.0.12",
   "scripts": {
     "babel:js": "jahia-babel-js",
     "babel:module": "jahia-babel-module",

--- a/packages/data-helper/src/fragments/PredefinedFragments.js
+++ b/packages/data-helper/src/fragments/PredefinedFragments.js
@@ -46,20 +46,6 @@ export const aggregatedPublicationInfo = {
     gql: gql`fragment AggregatedPublicationInfo on JCRNode {
         aggregatedPublicationInfo(language: $language, subNodes: $aggregatedPublicationInfoSubNodes, references:$aggregatedPublicationInfoIncludeReference) {
             publicationStatus
-        }
-    }`
-};
-
-export const aggregatedPublicationInfoWithExistInLive = {
-    variables: {
-        language: 'String!',
-        aggregatedPublicationInfoSubNodes: 'Boolean',
-        aggregatedPublicationInfoIncludeReference: 'Boolean'
-    },
-    applyFor: 'node',
-    gql: gql`fragment AggregatedPublicationInfoWithExistsInLive on JCRNode {
-        aggregatedPublicationInfo(language: $language, subNodes: $aggregatedPublicationInfoSubNodes, references:$aggregatedPublicationInfoIncludeReference) {
-            publicationStatus
             existsInLive
         }
     }`

--- a/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.js
+++ b/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.js
@@ -1,6 +1,5 @@
 import gql from 'graphql-tag';
 import {
-    aggregatedPublicationInfoWithExistInLive,
     aggregatedPublicationInfo,
     childNodeTypes,
     contentRestrictions,
@@ -125,7 +124,7 @@ export const validOptions = [
     'getMimeType'
 ];
 
-export const getQuery = (variables, schemaResult, options = {}) => {
+export const getQuery = (variables, options = {}) => {
     const fragments = [];
 
     const {baseQuery, generatedVariables, skip} = getBaseQueryAndVariables(variables);
@@ -156,13 +155,7 @@ export const getQuery = (variables, schemaResult, options = {}) => {
         }
 
         if (options.getAggregatedPublicationInfo) {
-            const supportsExistsInLive = schemaResult && schemaResult.__type && schemaResult.__type.fields && schemaResult.__type.fields.find(field => field.name === 'existsInLive') !== undefined;
-            if (supportsExistsInLive) {
-                fragments.push(aggregatedPublicationInfoWithExistInLive);
-            } else {
-                fragments.push(aggregatedPublicationInfo);
-            }
-
+            fragments.push(aggregatedPublicationInfo);
             if (!variables.language) {
                 throw Error('language is required');
             }

--- a/packages/scripts/publish.js
+++ b/packages/scripts/publish.js
@@ -34,9 +34,9 @@ const spawnSync = (command, params, options) => {
 
 console.log('Releasing code from branch : ' + branchName);
 
-// Ensure code is called from master
-if (branchName !== 'master') {
-    console.log('Can only release from master branch');
+// Ensure can only publish in master and backport branches
+if (branchName !== 'master' && !branchName.endsWith('_x')) {
+    console.log('Can only release from master or backport branches branch');
     process.exit(1);
 }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/SEC-104

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

Remove usage of `SCHEMA_FIELDS_QUERY` and `schemaResult` in `useNodeInfo()` 

From what I can tell, this has been added specifically to check for existence of `existsInLive` GQL field which should now exist since graphql-dxm-provider 2.1 version, and not needed anymore.