### PR TITLE
QA-15281 : copy react-matrials component to design-system-kit package to prevent endless loop in dependencies resolution.

### DIFF
--- a/packages/design-system-kit/package.json
+++ b/packages/design-system-kit/package.json
@@ -22,7 +22,8 @@
   "license": "MIT",
   "peerDependencies": {
     "@material-ui/core": "^3.9.3",
-    "react": "^16.8.0"
+    "react": "^16.8.0",
+    "rxjs": "^6.4.0"
   },
   "dependencies": {
     "@material-ui/core": "^3.9.3",

--- a/packages/design-system-kit/src/actions/DisplayAction.d.ts
+++ b/packages/design-system-kit/src/actions/DisplayAction.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export interface DisplayActionProps {
+}
+
+export class DisplayAction extends React.Component<DisplayActionProps, any> {
+    render(): JSX.Element;
+
+}
+

--- a/packages/design-system-kit/src/actions/DisplayAction.jsx
+++ b/packages/design-system-kit/src/actions/DisplayAction.jsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {actionsRegistry} from './actionsRegistry';
+import * as _ from 'lodash';
+import {Observable, combineLatest, of} from 'rxjs';
+import {first} from 'rxjs/operators';
+
+let count = 0;
+
+class StateActionComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {};
+    }
+
+    render() {
+        const enhancedContext = {...this.props.context, ...this.state};
+
+        if (enhancedContext.displayDisabled || (enhancedContext.enabled !== false && enhancedContext.enabled !== null)) {
+            const Render = this.props.render;
+            if (enhancedContext.actions) {
+                return _.map(enhancedContext.actions, action => (
+                    <Render key={action.key}
+                            context={{
+                    ...enhancedContext,
+                    ...action
+                }}/>
+                ));
+            }
+
+            return <Render context={enhancedContext}/>;
+        }
+
+        return false;
+    }
+}
+
+StateActionComponent.propTypes = {
+    context: PropTypes.object.isRequired,
+    render: PropTypes.func.isRequired
+};
+
+class DisplayActionComponent extends React.Component {
+    constructor(props) {
+        super(props);
+        this.innerRef = React.createRef();
+        this.state = {
+        };
+    }
+
+    render() {
+        const {context, render} = this.props;
+
+        const {subscription} = this;
+        if (subscription) {
+            subscription.unsubscribe();
+        }
+
+        let enhancedContext = {...context};
+        if (enhancedContext.init) {
+            enhancedContext.init(enhancedContext, _.omit(this.props, ['context']));
+        }
+
+        // Check observers
+        const observersObj = _.pickBy(enhancedContext, value => value instanceof Observable);
+        const keys = Object.keys(observersObj);
+
+        if (keys.length > 0) {
+            // Prepare an updateContext method for subscription - first set it as synchronous update of the context object
+            const update = v => {
+                if (this.innerRef.current) {
+                    this.innerRef.current.setState(v);
+                } else {
+                    enhancedContext = _.assign(enhancedContext, v);
+                }
+            };
+
+            // Concat with a sync observer to always get an initial value
+            const observers = Object.values(observersObj);
+
+            keys.forEach(k => _.set(enhancedContext, k, null));
+
+            // Related to https://jira.jahia.org/browse/QA-11271
+            // this empty subscription is auto cancelled with the first operator
+            // and resolve a problem where the observer was never resolved is some cases
+            _.each(observers, observer => observer.pipe(first()).subscribe());
+
+            // Combine all observers into one
+            const combinedObserver = combineLatest(...observers, (...vals) => _.zipObject(keys, vals));
+            this.subscription = combinedObserver.subscribe(v => update(v));
+            if (this.props.observerRef) {
+                this.props.observerRef(combinedObserver);
+            }
+        } else if (this.props.observerRef) {
+            this.props.observerRef(of(null));
+        }
+
+        return <StateActionComponent ref={this.innerRef} context={enhancedContext} render={render}/>;
+    }
+
+    componentWillUnmount() {
+        if (this.subscription) {
+            this.subscription.unsubscribe();
+        }
+
+        const {context} = this.props;
+        if (context.destroy) {
+            context.destroy(context);
+        }
+    }
+}
+
+DisplayActionComponent.defaultProps = {
+    observerRef: null
+};
+
+DisplayActionComponent.propTypes = {
+    context: PropTypes.object.isRequired,
+    render: PropTypes.func.isRequired,
+    observerRef: PropTypes.func
+};
+
+const shallowEquals = (obj1, obj2) =>
+    Object.keys(obj1).length === Object.keys(obj2).length &&
+    Object.keys(obj1).every(key => obj1[key] === obj2[key]);
+
+class DisplayAction extends React.Component {
+    constructor(props) {
+        super(props);
+        this.id = props.actionKey + '-' + (count++);
+
+        const {actionKey} = this.props;
+        const action = actionsRegistry.get(actionKey);
+
+        let Component = DisplayActionComponent;
+
+        if (action.wrappers) {
+            Component = _.reduce(action.wrappers, this.wrap.bind(this), DisplayActionComponent);
+        }
+
+        this.Component = Component;
+    }
+
+    shouldComponentUpdate(nextProps) {
+        return !shallowEquals(nextProps.context, this.props.context);
+    }
+
+    wrap(Render, wrapper) {
+        return props => wrapper(<Render key={this.id} {...props}/>);
+    }
+
+    render() {
+        const {context, actionKey, render, observerRef} = this.props;
+        const action = actionsRegistry.get(actionKey);
+        const enhancedContext = {...action, ...context, originalContext: context, id: this.id, actionKey};
+
+        const {Component} = this;
+
+        return <Component key={this.id} context={enhancedContext} render={render} actionKey={actionKey} observerRef={observerRef}/>;
+    }
+}
+
+DisplayAction.defaultProps = {
+    observerRef: null
+};
+
+DisplayAction.propTypes = {
+    actionKey: PropTypes.string.isRequired,
+    context: PropTypes.object.isRequired,
+    render: PropTypes.func.isRequired,
+    observerRef: PropTypes.func
+};
+
+export {DisplayAction};

--- a/packages/design-system-kit/src/actions/DisplayActions.d.ts
+++ b/packages/design-system-kit/src/actions/DisplayActions.d.ts
@@ -1,0 +1,10 @@
+import * as React from 'react';
+
+export interface DisplayActionsProps {
+}
+
+export class DisplayActions extends React.Component<DisplayActionsProps, any> {
+    render(): JSX.Element;
+
+}
+

--- a/packages/design-system-kit/src/actions/DisplayActions.jsx
+++ b/packages/design-system-kit/src/actions/DisplayActions.jsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {actionsRegistry} from './actionsRegistry';
+import * as _ from 'lodash';
+import {DisplayAction} from './DisplayAction';
+
+class DisplayActions extends React.Component {
+    constructor(props) {
+        super(props);
+        this.observerRefs = [];
+    }
+
+    render() {
+        const {target, context, render, filter} = this.props;
+
+        let actionsToDisplay = _.filter(actionsRegistry.getAll(), action => _.includes(_.map(action.target, 'id'), target));
+        actionsToDisplay = _.sortBy(actionsToDisplay, [function (o) {
+            const found = _.find(o.target, t => t.id === target);
+
+            if (found && found.priority) {
+                const priority = Number(found.priority);
+                if (!isNaN(priority) && priority !== 0) {
+                    return priority;
+                }
+            }
+
+            // Should be placed at the end if no priority defined, returning 'undefined' is making the ordering bug on FF and Opera
+            return 99999;
+        }]);
+
+        if (filter) {
+            actionsToDisplay = _.filter(actionsToDisplay, filter);
+        }
+
+        return _.map(actionsToDisplay, action => <DisplayAction key={action.key} context={context} actionKey={action.key} render={render} observerRef={obs => this.observerRefs.push(obs)}/>);
+    }
+}
+
+DisplayActions.defaultProps = {
+    filter: null
+};
+
+DisplayActions.propTypes = {
+    target: PropTypes.string.isRequired,
+    context: PropTypes.object.isRequired,
+    render: PropTypes.func.isRequired,
+    filter: PropTypes.func
+};
+
+export {DisplayActions};

--- a/packages/design-system-kit/src/actions/actionsRegistry.js
+++ b/packages/design-system-kit/src/actions/actionsRegistry.js
@@ -1,0 +1,38 @@
+import * as _ from 'lodash';
+import {composeActions} from './composeActions';
+
+class Registry {
+    constructor() {
+        this.registry = {};
+    }
+
+    add(key, ...actions) {
+        const action = composeActions(this.registry[key], ...actions);
+        action.key = key;
+
+        if (action.target) {
+            action.target = _.map(action.target, t => {
+                if (typeof t === 'string') {
+                    const spl = t.split(':');
+                    return ({id: spl[0], priority: spl[1] ? spl[1] : 0});
+                }
+
+                return t;
+            });
+        }
+
+        this.registry[key] = action;
+    }
+
+    get(key) {
+        return this.registry[key];
+    }
+
+    getAll() {
+        return _.values(this.registry);
+    }
+}
+
+const actionsRegistry = new Registry();
+
+export {actionsRegistry};

--- a/packages/design-system-kit/src/actions/composeActions.js
+++ b/packages/design-system-kit/src/actions/composeActions.js
@@ -1,0 +1,25 @@
+import * as _ from 'lodash';
+
+function composeActions(...actions) {
+    return _.reduce(actions, (acc, action) => {
+        if (action) {
+            _.forEach(action, (value, key) => {
+                const previous = acc[key];
+                if (typeof previous === 'function') {
+                    acc[key] = function (...args) {
+                        previous.apply(this, args);
+                        value.apply(this, args);
+                    };
+                } else if (Array.isArray(previous)) {
+                    acc[key] = _.concat(previous, value);
+                } else {
+                    acc[key] = value;
+                }
+            });
+        }
+
+        return acc;
+    }, {});
+}
+
+export {composeActions};

--- a/packages/design-system-kit/src/actions/index.js
+++ b/packages/design-system-kit/src/actions/index.js
@@ -1,0 +1,4 @@
+export {actionsRegistry} from './actionsRegistry';
+export {DisplayAction} from './DisplayAction';
+export {DisplayActions} from './DisplayActions';
+export {toIconComponent} from './toIconComponent';

--- a/packages/design-system-kit/src/actions/toIconComponent.jsx
+++ b/packages/design-system-kit/src/actions/toIconComponent.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import {SvgIcon} from '@material-ui/core';
+
+function toIconComponent(icon, props) {
+    const camelCased = s => s.replace(/-([a-z])/g, g => g[1].toUpperCase());
+
+    const toComp = function (node, idx) {
+        if (node.nodeType === 1) {
+            const props = {key: idx};
+            Array.prototype.slice.call(node.attributes).forEach(attr => {
+                props[camelCased(attr.name)] = attr.value;
+            });
+            const children = Array.prototype.slice.call(node.childNodes).map((child, idx) => toComp(child, idx));
+            return React.createElement(node.tagName, props, children);
+        }
+    };
+
+    if (typeof icon === 'string') {
+        if (icon.startsWith('<svg')) {
+            const parser = new DOMParser();
+            const doc = parser.parseFromString(icon, 'image/svg+xml');
+            const viewBox = doc.documentElement.attributes.viewBox ? doc.documentElement.attributes.viewBox.value : null;
+            const children = Array.prototype.slice.call(doc.documentElement.childNodes).map((child, idx) => toComp(child, idx));
+            return <SvgIcon viewBox={viewBox} {...props}>{children}</SvgIcon>;
+        }
+
+        return <img src={icon}/>;
+    }
+
+    if (props && icon) {
+        return React.cloneElement(icon, props);
+    }
+
+    return icon;
+}
+
+export {toIconComponent};

--- a/packages/design-system-kit/src/components/LeftNavigation/LeftDrawerContent/LeftDrawerListItems.jsx
+++ b/packages/design-system-kit/src/components/LeftNavigation/LeftDrawerContent/LeftDrawerListItems.jsx
@@ -3,7 +3,7 @@ import {List, ListItem, Typography, withStyles} from '@material-ui/core';
 import {ChevronRight, ExpandMore} from '@material-ui/icons';
 import React from 'react';
 import {lodash as _} from 'lodash';
-import {DisplayActions, toIconComponent} from '@jahia/react-material';
+import {DisplayActions, toIconComponent} from '../../../actions';
 import {compose} from 'recompose';
 
 const styles = theme => ({

--- a/packages/design-system-kit/src/components/LeftNavigation/LeftMenuItem.jsx
+++ b/packages/design-system-kit/src/components/LeftNavigation/LeftMenuItem.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {Badge, Button, Typography, withStyles} from '@material-ui/core';
 import {compose} from 'recompose';
-import {toIconComponent} from '@jahia/react-material';
+import {toIconComponent} from '../../actions';
 
 const styles = theme => ({
     badgeRoot: {

--- a/packages/design-system-kit/src/components/LeftNavigation/LeftNavigation.jsx
+++ b/packages/design-system-kit/src/components/LeftNavigation/LeftNavigation.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {List, withStyles} from '@material-ui/core';
 import classNames from 'classnames';
-import {DisplayActions} from '@jahia/react-material';
+import {DisplayActions} from '../../actions';
 import LeftMenuItem from './LeftMenuItem';
 import {compose} from 'recompose';
 import styleConstants from '../../theme/styleConstants';


### PR DESCRIPTION
https://jira.jahia.org/browse/QA-15281

A check on our code base shown that the updated component: `LeftNavivation` is not used internally. 
Note that the library is marked as deprecate since 2019. 
