### PR TITLE
QA-15281 : remove RXJS usage from design-system-kit

### DIFF
--- a/packages/design-system-kit/package.json
+++ b/packages/design-system-kit/package.json
@@ -22,8 +22,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@material-ui/core": "^3.9.3",
-    "react": "^16.8.0",
-    "rxjs": "^6.4.0"
+    "react": "^16.8.0"
   },
   "dependencies": {
     "@material-ui/core": "^3.9.3",


### PR DESCRIPTION
https://jira.jahia.org/browse/QA-15281 

Previous release introduce RXJS dependency that generated an inconsistencies with other bundles. 
this PR to remove it
We had to remove the refresh of the component (action), as the component is deprecated, and not used, this will have no impact.
The DisplayAction from ui-extender has to use instead:
https://github.com/Jahia/javascript-components/blob/master/packages/ui-extender/src/actions/core/DisplayAction.tsx