### PR TITLE
BACKLOG-23333: Pack from dist/build/ and deploy dist/*.tgz

### DIFF
--- a/packages/scripts/deploy.js
+++ b/packages/scripts/deploy.js
@@ -2,13 +2,16 @@
 require('dotenv').config();
 const {execSync} = require('child_process');
 const pack = require('./pack-project');
-const {getPackageFilename} = require("./pack-utility");
+const {getPackageFilename} = require('./pack-utility');
 const fs = require('fs');
-const path = require("path");
+const path = require('path');
 
 const args = process.argv.slice(2);
 const deployMethod = process.env.JAHIA_DEPLOY_METHOD;
 const packageFileName = getPackageFilename(path.join(process.cwd(), 'package.json'), process.env.npm_package_name, process.env.npm_package_version);
+const buildDir = path.resolve('dist/build');
+const packDir = fs.existsSync(buildDir) ? path.resolve('dist') : process.cwd();
+const packageFilePath = path.join(packDir, packageFileName);
 
 if (!fs.existsSync(packageFileName)) {
     console.log('Package hasn\'t been built previously, packing now using jahia-pack...');
@@ -20,8 +23,8 @@ if (!fs.existsSync(packageFileName)) {
 
 if (deployMethod === 'curl') {
     console.log('Deploying URL curl to Jahia bundles REST API...');
-    console.log(execSync(`curl -s --user ${process.env.JAHIA_USER} --form bundle=@./${packageFileName} --form start=true ${process.env.JAHIA_HOST}/modules/api/bundles`, {encoding: 'utf8'}));
+    console.log(execSync(`curl -s --user ${process.env.JAHIA_USER} --form bundle=@./${packageFilePath} --form start=true ${process.env.JAHIA_HOST}/modules/api/bundles`, {encoding: 'utf8'}));
 } else {
     console.log('Deploying using Docker copy...');
-    console.log(execSync(`docker cp ${packageFileName} ${process.env.JAHIA_DOCKER_NAME}:/var/jahia/modules`, {encoding: 'utf8'}));
+    console.log(execSync(`docker cp ${packageFilePath} ${process.env.JAHIA_DOCKER_NAME}:/var/jahia/modules`, {encoding: 'utf8'}));
 }

--- a/packages/scripts/pack-project.js
+++ b/packages/scripts/pack-project.js
@@ -1,22 +1,24 @@
 const {execSync} = require('child_process');
 const semver = require('semver');
 const path = require('path');
-const {getPackageFilename} = require("./pack-utility");
-
-
+const {getPackageFilename} = require('./pack-utility');
+const fs = require('fs');
 
 function pack() {
     console.log('Node version detected:', process.versions.node);
     const yarnVersion = execSync('yarn --version', {encoding: 'utf8'});
     console.log('Yarn version:', yarnVersion);
+    const buildDir = path.resolve('dist/build');
+    const packDir = fs.existsSync(buildDir) ? buildDir : process.cwd();
+    console.log(`Packing folder ${packDir}...`);
 
     if (semver.satisfies(yarnVersion, '1.x')) {
         console.log('Yarn Classic detected');
         console.log(execSync('yarn pack', {encoding: 'utf8'}));
     } else if (semver.gte(yarnVersion, '2.0.0')) {
         console.log('Yarn Berry detected');
-        const outputFileName = getPackageFilename(path.join(process.cwd(), 'package.json'),process.env.npm_package_name,process.env.npm_package_version);
-        console.log(execSync(`yarn pack --out ${outputFileName}`, {encoding: 'utf8'}));
+        const outputFileName = getPackageFilename(path.join(process.cwd(), 'package.json'), process.env.npm_package_name, process.env.npm_package_version);
+        console.log(execSync(`cd ${packDir} && yarn pack --out ${outputFileName} && mv ${outputFileName} ..`, {encoding: 'utf8'}));
     }
 }
 


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-23333

## Description

### Packing

Update the `pack-project.js` script (used by `yarn build`) to pack the content of the `dist/build/` folder into a `dist/<project>-<version>.tgz` file.
If the `dist/build` folder does not exist, fallback to the previous behaviour and pack the root directory directly. This way, we can first release a new version of `@jahia/scripts` that we can then use in https://github.com/Jahia/luxe-jahia-demo, https://github.com/Jahia/npm-create-module, etc.

### Deploying

Similarly, update the `deploy.js` script (used by `yarn deploy` and `yarn watch`) to deploy the `dist/<project>-<version>.tgz` file if `dist/build/` exists. Otherwise, it expects the archive file in the root folder of the project. 

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
