### PR TITLE
QA-15406: Fix curl deployment (yarn watch/deploy)

### DIFF
--- a/packages/scripts/deploy.js
+++ b/packages/scripts/deploy.js
@@ -23,7 +23,7 @@ if (!fs.existsSync(packageFileName)) {
 
 if (deployMethod === 'curl') {
     console.log('Deploying URL curl to Jahia bundles REST API...');
-    console.log(execSync(`curl -s --user ${process.env.JAHIA_USER} --form bundle=@./${packageFilePath} --form start=true ${process.env.JAHIA_HOST}/modules/api/bundles`, {encoding: 'utf8'}));
+    console.log(execSync(`curl -s --user ${process.env.JAHIA_USER} --form bundle=@${packageFilePath} --form start=true ${process.env.JAHIA_HOST}/modules/api/bundles`, {encoding: 'utf8'}));
 } else {
     console.log('Deploying using Docker copy...');
     console.log(execSync(`docker cp ${packageFilePath} ${process.env.JAHIA_DOCKER_NAME}:/var/jahia/modules`, {encoding: 'utf8'}));


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->
https://jira.jahia.org/browse/QA-15406

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->
For the javascript modules, fix the deployment with curl for the `yarn watch` and `yarn deploy` commands.

With a new javascript modules freshly created with `npx @jahia/create-module@latest my-module` (using version _0.0.6_), `yarn watch` and `yarn deploy` commands fail with the following error:
```
Deploying URL curl to Jahia bundles REST API...
node:child_process:965
    throw err;
    ^

Error: Command failed: curl -s --user "root:root1234" --form 'bundle=@.//Users/baptistegrimaud/Documents/code/playground/my-module/dist/my-module-v0.1.0-SNAPSHOT.tgz' --form start=true "http://localhost:8080/modules/api/bundles"
```
The root cause is that the path to the tgz is an absolute path when the curl command expects a relative path.

