### PR TITLE
feat: Allow multiple targets for DisplayActions

### DIFF
--- a/packages/ui-extender/src/actions/core/DisplayActions.tsx
+++ b/packages/ui-extender/src/actions/core/DisplayActions.tsx
@@ -40,7 +40,10 @@ export const DisplayActions = ({target, filter, ...others}: DisplayActionsProps)
     }
 
     targets.forEach(t => {
-        actionsToDisplay.push(...registry.find({type: 'action', target: t}).filter(filter ? filter : () => true).map(action => <DisplayAction {...others} key={action.key} target={t} actionKey={action.key}/>));
+        const actions = registry.find({type: 'action', target: t})
+            .filter(filter ? filter : () => true)
+            .map(action => <DisplayAction {...others} key={action.key} target={t} actionKey={action.key}/>);
+        actionsToDisplay.push(...actions);
     });
 
     return <>{actionsToDisplay}</>;

--- a/packages/ui-extender/src/actions/core/DisplayActions.tsx
+++ b/packages/ui-extender/src/actions/core/DisplayActions.tsx
@@ -30,13 +30,20 @@ export type DisplayActionsProps = {
 }
 
 export const DisplayActions = ({target, filter, ...others}: DisplayActionsProps) => {
-    let actionsToDisplay = registry.find({type: 'action', target});
+    const actionsToDisplay: any[] = [];
+    let targets = [];
 
-    if (filter) {
-        actionsToDisplay = actionsToDisplay && actionsToDisplay.filter(filter);
+    if (Array.isArray(target)) {
+        targets = target;
+    } else {
+        targets.push(target);
     }
 
-    return <>{actionsToDisplay.map(action => <DisplayAction {...others} key={action.key} target={target} actionKey={action.key}/>)}</>;
+    targets.forEach(t => {
+        actionsToDisplay.push(...registry.find({type: 'action', target: t}).filter(filter ? filter : () => true).map(action => <DisplayAction {...others} key={action.key} target={t} actionKey={action.key}/>));
+    });
+
+    return <>{actionsToDisplay}</>;
 };
 
 DisplayActions.defaultProps = {


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Allow multiple targets for DisplayActions

So we can do: menuTarget: ['contentActions', 'otherActions']