### PR TITLE
chore: Deprecate pack/deploy scripts

### DIFF
--- a/packages/scripts/deploy.js
+++ b/packages/scripts/deploy.js
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+console.log("⚠ Deprecated ⚠ : Please deploy with 'jahia-deploy' provided by @jahia/javascript-modules-library.")
+
 require('dotenv').config();
 const {execSync} = require('child_process');
 const pack = require('./pack-project');

--- a/packages/scripts/pack-project.js
+++ b/packages/scripts/pack-project.js
@@ -4,7 +4,11 @@ const path = require('path');
 const {getPackageFilename} = require('./pack-utility');
 const fs = require('fs');
 
+/**
+ * @deprecated Use `yarn pack --out package.tgz` instead. The renaming (to include the module name & version) is done by the CI.
+ */
 function pack() {
+    console.log("⚠ Deprecated ⚠ : Please pack with 'yarn pack' directly.")
     console.log('Node version detected:', process.versions.node);
     const yarnVersion = execSync('yarn --version', {encoding: 'utf8'});
     console.log('Yarn version:', yarnVersion);

--- a/packages/scripts/pack-utility.js
+++ b/packages/scripts/pack-utility.js
@@ -1,5 +1,8 @@
 const fs = require('fs');
 
+/**
+ * @deprecated No longer needed as the packing should be done with `yarn pack --out package.tgz` directly instead
+ */
 function getPackageFilename(packageJsonPath, packageName, packageVersion) {
     const packageJsonContent = fs.readFileSync(packageJsonPath, { encoding: 'utf8' });
     const packageJson = JSON.parse(packageJsonContent);

--- a/packages/scripts/pack.js
+++ b/packages/scripts/pack.js
@@ -1,3 +1,6 @@
 #!/usr/bin/env node
+/**
+ * @deprecated Use `yarn pack --out package.tgz` instead. The renaming (to include the module name & version) is done by the CI.
+ */
 const pack = require('./pack-project');
 pack();


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## Description

Deprecating `jahia-pack` and `jahia-deploy` script provided by _@jahia/scripts_ package as packing should now be performed with `yarn pack` while packing should be done with the `jahia-deploy` script provided by _@jahia/javsscript-modules-library_ package.
