### PR TITLE
fix: Make @jahia/data-helper a singleton dependency

### DIFF
--- a/packages/webpack-config/getModuleFederationConfig.js
+++ b/packages/webpack-config/getModuleFederationConfig.js
@@ -56,6 +56,7 @@ const singletonDeps = [
     'redux',
     '@jahia/moonstone',
     '@jahia/ui-extender',
+    '@jahia/data-helper',
     '@apollo/client',
     '@apollo/react-common',
     '@apollo/react-components',


### PR DESCRIPTION
### Description

Make @jahia/data-helper a singleton dependency (so that it is loaded only once in the shared scope) so that fragments are registered only once to prevent apollo warnings.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
