### PR TITLE
fix: Include __mocks__ folder in @jahia/test-framework build

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,2 +1,1 @@
 nodeLinker: node-modules
-yarnPath: .yarn/releases/yarn-1.22.22.cjs

--- a/package.json
+++ b/package.json
@@ -77,5 +77,5 @@
     "workspaces": [
         "packages/*"
     ],
-    "packageManager": "yarn@1.22.22"
+    "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/packages/test-framework/babel-test.js
+++ b/packages/test-framework/babel-test.js
@@ -1,0 +1,21 @@
+#!/usr/bin/env node
+const babel = require('../scripts/babel');
+
+console.log('Transpiling for js');
+
+const testIgnore = [
+    // Remove __mocks__/** from the default ignore list
+    '__storybook__/**',
+    '**/*.test.[tj]s',
+    '**/*.spec.[tj]s',
+    '**/*.test.[tj]sx',
+    '**/*.spec.[tj]sx',
+    '**/*.stories.[tj]sx',
+    '**/*.d.ts'
+];
+
+babel('build/js', {
+    presets: [['@babel/env'], '@babel/react'],
+    sourceMaps: true,
+    plugins: ['lodash', '@babel/plugin-syntax-dynamic-import', '@jahia/scripts/dynamic-to-static']
+}, testIgnore);

--- a/packages/test-framework/package.json
+++ b/packages/test-framework/package.json
@@ -2,7 +2,7 @@
   "name": "@jahia/test-framework",
   "version": "1.3.0",
   "scripts": {
-    "build": "jahia-babel-js",
+    "build": "./babel-test.js",
     "publish-script": "jahia-publish"
   },
   "description": "This Jahia test-framework for React Apps",


### PR DESCRIPTION
### Description

Include `__mocks__` folder in @jahia/test-framework build by overriding the [default ignore list](https://github.com/Jahia/javascript-components/blob/master/packages/scripts/babel.js#L8). 

`__mocks__` folder is used in the jest config.

Also cleanup - remove embedded yarn.

Tested locally with jcontent and build structure seems to be working 