### PR TITLE
fix: Remove usage of introspection query SCHEMA_FIELDS_QUERY

### DIFF
--- a/packages/data-helper/src/fragments/PredefinedFragments.ts
+++ b/packages/data-helper/src/fragments/PredefinedFragments.ts
@@ -55,20 +55,6 @@ export const aggregatedPublicationInfo: Fragment = {
     gql: gql`fragment AggregatedPublicationInfo on JCRNode {
         aggregatedPublicationInfo(language: $language, subNodes: $aggregatedPublicationInfoSubNodes, references:$aggregatedPublicationInfoIncludeReference) {
             publicationStatus
-        }
-    }`
-};
-
-export const aggregatedPublicationInfoWithExistInLive: Fragment = {
-    variables: {
-        language: 'String!',
-        aggregatedPublicationInfoSubNodes: 'Boolean',
-        aggregatedPublicationInfoIncludeReference: 'Boolean'
-    },
-    applyFor: 'node',
-    gql: gql`fragment AggregatedPublicationInfoWithExistsInLive on JCRNode {
-        aggregatedPublicationInfo(language: $language, subNodes: $aggregatedPublicationInfoSubNodes, references:$aggregatedPublicationInfoIncludeReference) {
-            publicationStatus
             existsInLive
         }
     }`

--- a/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.ts
+++ b/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.ts
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag';
 import {
     aggregatedPublicationInfo,
-    aggregatedPublicationInfoWithExistInLive,
     canLockUnlock,
     childNodeTypes,
     contentRestrictions,
@@ -166,8 +165,7 @@ export const validOptions = [
     'applyFragment'
 ];
 
-// eslint-disable-next-line complexity
-export const getQuery = (variables: {[key:string]: any}, schemaResult: any, options: NodeInfoOptions = {}) => {
+export const getQuery = (variables: {[key:string]: any}, options: NodeInfoOptions = {}) => {
     const fragments = [];
 
     const {baseQuery, generatedVariables, skip} = getBaseQueryAndVariables(variables);
@@ -198,13 +196,7 @@ export const getQuery = (variables: {[key:string]: any}, schemaResult: any, opti
         }
 
         if (options.getAggregatedPublicationInfo) {
-            const supportsExistsInLive = schemaResult && schemaResult.__type && schemaResult.__type.fields && schemaResult.__type.fields.find((field: any) => field.name === 'existsInLive') !== undefined;
-            if (supportsExistsInLive) {
-                fragments.push(aggregatedPublicationInfoWithExistInLive);
-            } else {
-                fragments.push(aggregatedPublicationInfo);
-            }
-
+            fragments.push(aggregatedPublicationInfo);
             if (!variables.language) {
                 throw Error('language is required');
             }


### PR DESCRIPTION
### Description

Port 8.1 change https://github.com/Jahia/javascript-components/pull/271 to latest `data-helper` and remove usage of introspection query:

> Remove usage of SCHEMA_FIELDS_QUERY and schemaResult in useNodeInfo()
> 
> From what I can tell, this has been added specifically to check for existence of existsInLive GQL field which should now exist since graphql-dxm-provider 2.1 version, and not needed anymore.

Needed to fix breaking change in graphql-core (TBC)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
