### PR TITLE
chore: Remove @apollo/react-components dependency

### DIFF
--- a/packages/data-helper/package.json
+++ b/packages/data-helper/package.json
@@ -17,7 +17,6 @@
   "license": "SEE LICENSE IN ../../LICENSE.txt FILE",
   "dependencies": {
     "@apollo/client": "^3.7.14",
-    "@apollo/react-components": "^4.0.0",
     "fast-deep-equal": "^3.1.1",
     "graphql": "^15.4.0",
     "graphql-tag": "^2.11.0",

--- a/packages/data-helper/src/legacy/Picker.tsx
+++ b/packages/data-helper/src/legacy/Picker.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-nocheck
 import React from 'react';
-import {Query} from '@apollo/react-components';
+import {Query} from '@apollo/client/react/components';
 import gql from 'graphql-tag';
 import {displayName, Fragment, nodeCacheRequiredFields, replaceFragmentsInDocument} from '../fragments';
 import {PickerItemsFragment} from './Picker.gql-fragments';

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@apollo/client@^3.7.14", "@apollo/client@latest":
+"@apollo/client@^3.7.14":
   version "3.7.17"
   resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.7.17.tgz#1d2538729fd8ef138aa301a7cf62704474e57b72"
   integrity sha512-0EErSHEtKPNl5wgWikHJbKFAzJ/k11O0WO2QyqZSHpdxdAnw7UWHY4YiLbHCFG7lhrD+NTQ3Z/H9Jn4rcikoJA==
@@ -33,13 +33,6 @@
     ts-invariant "^0.10.3"
     tslib "^2.3.0"
     zen-observable-ts "^1.2.5"
-
-"@apollo/react-components@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@apollo/react-components/-/react-components-4.0.0.tgz#4d994708337eaa117a5e639b4a664f0e560663d3"
-  integrity sha512-JI0qnvROVC8bPbtPVzHKNHkDhohv8f8a8DNGjyI9seLeB2V0NMT3c1qEUs+zsu0W+SdDdRaUKE3DjsEuxj92Ew==
-  dependencies:
-    "@apollo/client" latest
 
 "@auto-it/bot-list@11.3.0":
   version "11.3.0"


### PR DESCRIPTION
### Description

Remove deprecated `@apollo/react-components` dependency and switch to `@apollo/client` instead

https://github.com/apollographql/react-apollo


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
