### PR TITLE
fix: Allow to use skip in useNodeInfo query

### DIFF
--- a/.chachalog/YC4eEyI3.md
+++ b/.chachalog/YC4eEyI3.md
@@ -1,0 +1,16 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/data-helper": patch
+# "@jahia/design-system-kit": patch
+# "@jahia/eslint-config": patch
+# "@jahia/icons": patch
+# "@jahia/react-material": patch
+# "@jahia/scripts": patch
+# "@jahia/stylelint-config": patch
+# "@jahia/test-framework": patch
+# "@jahia/ui-extender": patch
+# "@jahia/vite-federation-plugin": patch
+# "@jahia/webpack-config": patch
+---
+
+Allow to skip on useNodeInfo query (#352)

--- a/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.ts
+++ b/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.ts
@@ -140,7 +140,8 @@ export type NodeInfoOptions = Partial<{
     getContributeTypesRestrictions: boolean,
     getSubNodesCount: string[],
     getMimeType: boolean,
-    applyFragment: Fragment
+    applyFragment: Fragment,
+    skip: boolean
 }>;
 
 export const validOptions = [
@@ -162,7 +163,8 @@ export const validOptions = [
     'getContributeTypesRestrictions',
     'getSubNodesCount',
     'getMimeType',
-    'applyFragment'
+    'applyFragment',
+    'skip'
 ];
 
 export const validateQuery = (variables: {[key:string]: any}, options: NodeInfoOptions = {}) => {

--- a/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.ts
+++ b/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.ts
@@ -146,7 +146,7 @@ export const useNodeInfo = (variables: {[key:string]: unknown}, options?: NodeIn
     // Normalize and memoize request
     const [currentRequest, queryHasChanged] = useMemoRequest(variables, queryOptions, options, setResult);
     useEffect(() => {
-        if (validationError) {
+        if (validationError || options?.skip) {
             return;
         }
 
@@ -156,11 +156,15 @@ export const useNodeInfo = (variables: {[key:string]: unknown}, options?: NodeIn
         return () => {
             queue.splice(queue.indexOf(currentRequest), 1);
         };
-    }, [client, currentRequest, validationError]);
+    }, [client, currentRequest, options?.skip, validationError]);
 
     // Return early with error if validation failed
     if (validationError) {
         return {loading: false, error: validationError};
+    }
+
+    if (options?.skip) {
+        return {loading: false};
     }
 
     if (queryHasChanged && queryOptions?.fetchPolicy !== 'no-cache' && queryOptions?.fetchPolicy !== 'network-only') {


### PR DESCRIPTION
### Description
Allow to use skip in useNodeInfo query.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
