### PR TITLE
fix: add missing metadata fields to package.json

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@jahia/eslint-config",
   "version": "2.2.0",
+  "bugs": {
+    "url": "https://github.com/Jahia/javascript-components/issues"
+  },
   "description": "ESLint shareable config for Jahia project",
   "main": "index.js",
   "license": "MIT",


### PR DESCRIPTION
Adds missing `bugs` metadata to `packages/eslint-config/package.json`.