### PR TITLE
fix(data-helper): require/inject language for getChildNodeTypes

### DIFF
--- a/.chachalog/EhDvjZqy.md
+++ b/.chachalog/EhDvjZqy.md
@@ -1,0 +1,16 @@
+---
+# Allowed version bumps: patch, minor, major
+"@jahia/data-helper": patch
+# "@jahia/design-system-kit": patch
+# "@jahia/eslint-config": patch
+# "@jahia/icons": patch
+# "@jahia/react-material": patch
+# "@jahia/scripts": patch
+# "@jahia/stylelint-config": patch
+# "@jahia/test-framework": patch
+# "@jahia/ui-extender": patch
+# "@jahia/vite-federation-plugin": patch
+# "@jahia/webpack-config": patch
+---
+
+Require/inject language for getChildNodeTypes (#382)

--- a/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.ts
+++ b/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.ts
@@ -168,7 +168,7 @@ export const validOptions = [
 ];
 
 export const validateQuery = (variables: {[key:string]: any}, options: NodeInfoOptions = {}) => {
-    const requiresLanguage = ['getDisplayName', 'getAggregatedPublicationInfo', 'getProperties'] as const;
+    const requiresLanguage = ['getDisplayName', 'getAggregatedPublicationInfo', 'getProperties', 'getChildNodeTypes'] as const;
     const missingLanguageOptions = requiresLanguage
         .filter(attr => Boolean(options[attr as keyof NodeInfoOptions]));
     if (missingLanguageOptions.length > 0 && !variables.language) {
@@ -270,6 +270,7 @@ export const getQuery = (variables: {[key:string]: any}, options: NodeInfoOption
 
         if (options.getChildNodeTypes) {
             fragments.push(childNodeTypes);
+            generatedVariables.language = variables.language;
         }
 
         if (options.getContributeTypesRestrictions) {

--- a/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.test.js
+++ b/packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.test.js
@@ -211,6 +211,23 @@ describe('useNodeInfo', () => {
         expect(result.value.query.definitions.map(d => d.name.value)).toContain('CanLockUnlockInfo');
     });
 
+    it('should request child node types with language', async () => {
+        const setStateMock = jest.fn();
+        const useStateMock = useState => [useState, setStateMock];
+        jest.spyOn(React, 'useState').mockImplementation(useStateMock);
+        useNodeInfo({path: '/test', language: 'en'}, {getChildNodeTypes: true});
+
+        await wait();
+
+        expect(getQuery).toHaveBeenCalled();
+        const {mock} = getQuery;
+        const result = mock.results[mock.results.length - 1];
+        const variables = result.value.generatedVariables;
+        result.value.query.definitions[0].variableDefinitions.map(v => v.variable.name.value).forEach(v => expect(Object.keys(variables)).toContain(v));
+        expect(variables.language).toBe('en');
+        expect(result.value.query.definitions.map(d => d.name.value).some(name => name.includes('AllowedChildNodeType'))).toBe(true);
+    });
+
     it('should request all data', async () => {
         const setStateMock = jest.fn();
         const useStateMock = useState => [useState, setStateMock];
@@ -295,6 +312,16 @@ describe('useNodeInfo', () => {
         const useStateMock = useState => [useState, setStateMock];
         jest.spyOn(React, 'useState').mockImplementation(useStateMock);
         const result = useNodeInfo({path: '/test'}, {getProperties: ['propA']});
+        expect(result.error).toBeDefined();
+        expect(result.error.message).toContain('language is required for useNodeInfo options');
+        expect(result.loading).toBe(false);
+    });
+
+    it('should return error when getChildNodeTypes is used without language', () => {
+        const setStateMock = jest.fn();
+        const useStateMock = useState => [useState, setStateMock];
+        jest.spyOn(React, 'useState').mockImplementation(useStateMock);
+        const result = useNodeInfo({path: '/test'}, {getChildNodeTypes: true});
         expect(result.error).toBeDefined();
         expect(result.error.message).toContain('language is required for useNodeInfo options');
         expect(result.loading).toBe(false);


### PR DESCRIPTION
## What this PR fixes
This PR fixes a GraphQL variable mismatch affecting `useNodeInfo` / `useNodeChecks` when `getChildNodeTypes` is enabled.
## Root cause
The child node types fragment uses localized display names and requires `language`, but:
- `getChildNodeTypes` was not treated as a language-required option during validation
- `generatedVariables.language` was not explicitly assigned in the `getChildNodeTypes` query generation branch
## Changes
### Code
- `packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.gql-queries.ts`
  - Added `getChildNodeTypes` to `requiresLanguage` in `validateQuery`
  - Added `generatedVariables.language = variables.language` when `options.getChildNodeTypes` is true
### Tests
- `packages/data-helper/src/hooks/useNodeInfo/useNodeInfo.test.js`
  - Added test to ensure `getChildNodeTypes` with language generates valid variables including `language`
  - Added test to ensure `getChildNodeTypes` without language returns a clear validation error
## Validation
Executed:
```bash
cd /home/jerome/Work/javascript-components/packages/data-helper
yarn run --top-level jest src/hooks/useNodeInfo/useNodeInfo.test.js --runInBand --config ./jest.config.js
```
Result: `PASS` (16 tests passed).
## Risk
Low and localized to variable validation/injection for child node type query path.
Closes #381
